### PR TITLE
add note to CHANGELOG about Ruby 2.4 deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 # 3.3.3
 
+* Remove deprecation warnings in Ruby 2.4 related to `Fixnum` vs `Integer`
+
 * Improved timeout handling after dropping Timeout module.
 
 # 3.3.2


### PR DESCRIPTION
I noticed that as of 3.3.3, redis-rb no longer raises deprecation warnings on
Ruby 2.4 related to `Fixnum` etc (see #660), but the CHANGELOG doesn't reflect
this.

Updated the changelog with the new info ;)